### PR TITLE
ci: set permissions on workflows

### DIFF
--- a/.github/workflows/ci-nuget.yml
+++ b/.github/workflows/ci-nuget.yml
@@ -2,6 +2,7 @@ name: CI Nuget
 
 permissions:
   contents: read
+  packages: write
 
 on:
   push:

--- a/.github/workflows/ci-nuget.yml
+++ b/.github/workflows/ci-nuget.yml
@@ -1,5 +1,8 @@
 name: CI Nuget
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -1,5 +1,8 @@
 name: Release Nuget
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -2,7 +2,6 @@ name: Release Nuget
 
 permissions:
   contents: read
-  packages: write
 
 on:
   workflow_dispatch:
@@ -60,6 +59,8 @@ jobs:
   push-to-github:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
     - name: Download NuGet packages from artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -2,6 +2,7 @@ name: Release Nuget
 
 permissions:
   contents: read
+  packages: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### Description
<!--- What and why -->

### Documentation
- [ ] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow permissions to set repository contents to read by default and grant package write where needed, establishing explicit workflow- and job-level permission scopes for package publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->